### PR TITLE
[TASK] Remove `@internal` flag from ServiceConfigurator

### DIFF
--- a/src/DependencyInjection/ServiceConfigurator.php
+++ b/src/DependencyInjection/ServiceConfigurator.php
@@ -33,8 +33,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
 final class ServiceConfigurator
 {


### PR DESCRIPTION
`ServiceConfigurator` is explicitly mentioned in documentation to be used for DI auto-configuration. Hence, it must not be marked as `@internal`.